### PR TITLE
Add track info to bottom left

### DIFF
--- a/components/CurrentPlaybackInfo.tsx
+++ b/components/CurrentPlaybackInfo.tsx
@@ -1,0 +1,73 @@
+import styled from "styled-components";
+import { SimplifiedArtist } from "./types";
+
+export const CurrentPlaybackInfo = ({
+  imgUrl,
+  trackTitle,
+  artists,
+  onTrackClick,
+  onArtistClick,
+}: {
+  imgUrl?: string;
+  trackTitle?: string;
+  artists?: SimplifiedArtist[];
+  onTrackClick: VoidFunction;
+  onArtistClick: (artist: SimplifiedArtist) => void;
+}) => {
+  return (
+    <Container>
+      <img src={imgUrl} width={64} height={64} />
+      <LinksContainer>
+        <ArtistNameButton onClick={onTrackClick}>{trackTitle}</ArtistNameButton>
+        <div>
+          {artists?.map((artist, index) => {
+            const lastItem = index == artists.length - 1;
+
+            return (
+              <ArtistLinkButton
+                onClick={() => onArtistClick(artist)}
+                key={artist.id}
+              >
+                {lastItem ? artist.name : `${artist.name},`}
+              </ArtistLinkButton>
+            );
+          })}
+        </div>
+      </LinksContainer>
+    </Container>
+  );
+};
+
+// todo this should likely be an <a>, but we should have router to use it properly
+const LinkButton = styled.button`
+  border: none;
+  background: none;
+  color: var(--text-on-main-bg);
+  cursor: pointer;
+  padding: 1px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const ArtistNameButton = styled(LinkButton)`
+  font-weight: bold;
+`;
+
+const ArtistLinkButton = styled(LinkButton)`
+  color: var(--diminished-text-color);
+  display: inline;
+`;
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const LinksContainer = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  align-items: start;
+`;

--- a/components/TracksList/TracksList.tsx
+++ b/components/TracksList/TracksList.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Track } from "../types";
+import { LegacyTrack } from "../types";
 import { useState } from "react";
 import { PlayPauseButton } from "./PlayPauseButton";
 import { ClockButton } from "../IconButtons/IconButtons";
@@ -27,7 +27,7 @@ const TrackRow = ({
   pausePlayback,
   isPlaybackPaused,
 }: {
-  track: Track;
+  track: LegacyTrack;
   playCurrentTrack: (param: string) => void;
   pausePlayback: VoidFunction;
   index: number;
@@ -82,9 +82,9 @@ export const TracksList = ({
   pausePlayback,
   isPlaybackPaused,
 }: {
-  tracks: Track[];
+  tracks: LegacyTrack[];
   playCurrentTrack: React.ComponentProps<typeof TrackRow>["playCurrentTrack"];
-  currentlyPlayingTrack?: Track;
+  currentlyPlayingTrack?: LegacyTrack;
   pausePlayback: React.ComponentProps<typeof TrackRow>["pausePlayback"];
   isPlaybackPaused: boolean;
 }) => {

--- a/components/types.tsx
+++ b/components/types.tsx
@@ -1,22 +1,55 @@
+import { URL } from "url";
+
 export type PromiseVoidFunction = () => Promise<void>;
 
-export type Track = {
+// todo this is not a spotify track
+export type LegacyTrack = {
   name: string;
   uri: string;
   imgUri?: string;
   id: string;
 };
 
-export type SpotifyItem = {
-  album: any;
-  artists: any[];
+type Image = {
+  url: string;
+  height: number;
+  width: number;
+};
+
+export type SimplifiedArtist = {
+  href: URL;
+  id: string;
+  name: string;
+  uri: string;
+};
+
+type Album = {
+  total_tracks: number;
+  href: string;
+  images: Image[];
+  name: string;
+  release_date: string;
+  uri: string;
+  artists: SimplifiedArtist[];
+};
+
+// music
+export type SpotifyTrackItem = {
+  album: Album;
+  artists: SimplifiedArtist[];
   duration_ms: number;
   id: string;
   name: string;
   popularity: number;
   track_number: number;
   uri: string;
+  type: "track";
   // todo there's more fields...
+};
+
+// podcast
+export type SpotifyEpisodeItem = {
+  type: "episode";
 };
 
 export type SpotifyActions = {
@@ -33,10 +66,23 @@ export type SpotifyDevice = {
   supports_volume: string;
 };
 
-export type PlaybackStatusResponse = {
-  item: SpotifyItem;
+type GenericPlaybackStatusResponse = {
   actions: SpotifyActions;
   device: SpotifyDevice;
   progress_ms: number;
   is_playing: boolean;
 };
+
+type TrackPlaybackStatusResponse = GenericPlaybackStatusResponse & {
+  item: SpotifyTrackItem;
+  currently_playing_type: "track";
+};
+
+type EpisodePlaybackStatusResponse = GenericPlaybackStatusResponse & {
+  item: SpotifyEpisodeItem;
+  currently_playing_type: "episode";
+};
+
+export type PlaybackStatusResponse =
+  | TrackPlaybackStatusResponse
+  | EpisodePlaybackStatusResponse;

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -11,22 +11,17 @@
   grid-template-areas:
     "header header header"
     "leftnav maincontent rightnav"
-    "bottomleft bottomcenter bottomright";
+    "bottom bottom bottom";
 }
 
-.bottomLeft {
+.bottomGrid {
   background-color: var(--main-bg-black);
-  grid-area: bottomleft;
-}
-
-.bottomCenter {
-  background-color: var(--main-bg-black);
-  grid-area: bottomcenter;
-}
-
-.bottomRight {
-  background-color: var(--main-bg-black);
-  grid-area: bottomright;
+  grid-area: bottom;
+  padding: 0 25px;
+  display: grid;
+  grid-template-columns: 1fr 2fr 1fr;
+  grid-template-rows: 1fr;
+  align-items: center;
 }
 
 .searchNavBar {
@@ -112,7 +107,9 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition: color 0.15s ease, border-color 0.15s ease;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .card:hover,


### PR DESCRIPTION
- update the bottom bar to be just one grid area instead of being divided,
this makes it easier to line
up the items in the bottom bar
- add the album image, track name and artists to the bottom left
- additional types for the API responses